### PR TITLE
Fix a typo in purge.yml

### DIFF
--- a/ansible/purge.yml
+++ b/ansible/purge.yml
@@ -31,7 +31,7 @@
       state: absent
     with_items:
       - /var/lib/graphite
-      - /var/lig/graphite-web
+      - /var/lib/graphite-web
       - /var/lib/grafana
       - /var/lib/carbon
       - /etc/grafana/grafana.ini


### PR DESCRIPTION
This patchset will fix a typo in the purge.yml Ansible playbook.
